### PR TITLE
Retouch

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,7 +4,7 @@ class StaticPagesController < ApplicationController
   def privacy; end
 
   def terms_of_service; end
-  
+
   def how_to_use; end
 end
 # ルートページ

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,5 +2,9 @@ class StaticPagesController < ApplicationController
   def top; end
 
   def privacy; end
+
+  def terms_of_service; end
+  
+  def how_to_use; end
 end
 # ルートページ

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -72,7 +72,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # DELETE /resource
   def destroy
     if current_user.admin? && only_one_admin?(current_user)
-      redirect_to confirm_delete_user_path, alert: "チームに1人しか管理者がいないため、アカウントを削除できません。"
+      redirect_to confirm_delete_user_path, alert: "チームに1人しか管理者がいないため、アカウントを削除できません。管理者を増やすか、チームを削除してください。"
       return
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,7 +62,7 @@ class UsersController < ApplicationController
 
   def leave_team
     if current_user.admin? && only_one_admin?(current_user)
-      redirect_to user_path(current_user), alert: "チームに1人しか管理者がいないため、チームを脱退できません。"
+      redirect_to user_path(current_user), alert: "チームに1人しか管理者がいないため、アカウントを削除できません。管理者を追加、もしくは権限を譲渡してください。"
       return
     end
 
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
     user = User.find(params[:id])
 
     if admin_count_for_team >= 5
-      redirect_to users_path, alert: "このチームにはすでに5人の管理者がいます。"
+      redirect_to users_path, alert: "管理者はチームに５名までです。"
       return
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,9 @@ module ApplicationHelper
     def button_class
      "relative h-6 overflow-hidden rounded-md border border-neutral-600 bg-transparent px-6 text-neutral-950 transition-transform duration-150 ease-in-out active:scale-95 active:bg-neutral-300"
     end
+
+    def login_button_class
+      "relative h-6 overflow-hidden rounded-md border border-blue-600 bg-blue-600 text-white px-6 transition-transform duration-150 ease-in-out hover:bg-blue-700 active:scale-95"
+    end
+    
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,5 +32,4 @@ module ApplicationHelper
     def login_button_class
       "relative h-6 overflow-hidden rounded-md border border-blue-600 bg-blue-600 text-white px-6 transition-transform duration-150 ease-in-out hover:bg-blue-700 active:scale-95"
     end
-    
 end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,6 +1,6 @@
 
 <% if controller_name != 'sessions' %>
-  <%= link_to "ログイン", new_user_session_path, class: button_class %><br />
+  <%= link_to "ログイン", new_user_session_path, class: login_button_class %><br />
 <% end %>
 
 <br>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,8 +29,6 @@
     <div class="hidden lg:block">
     <% if user_signed_in? %>
       <%= render 'shared/footer' %>
-    <% else %>
-      <%= render 'shared/before_login_footer' %>
     <% end %>
   </div>
 
@@ -53,8 +51,6 @@
   <div class="block lg:hidden">
     <% if user_signed_in? %>
       <%= render 'shared/footer' %>
-    <% else %>
-      <%= render 'shared/before_login_footer' %>
     <% end %>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,6 @@
 
   
 
-
   <main class="flex-grow pb-12">
     <%= yield %>
   </main>
@@ -54,8 +53,8 @@
     <% end %>
   </div>
 
-  <% unless user_signed_in? %>
-    <%= render 'shared/before_login_privacy' %>
-  <% end %>
+
+    <%= render 'shared/fotter_fixed' %>
+
   </body>
 </html>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,6 +1,0 @@
-<footer class="bg-gray-100 text-center py-2 text-gray-500 z-40">
-    <div class="bg-blue-500 text-white ">
-       <p>ログインしていません</p>
-    </div>
-</footer>
-

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,5 @@
 <header class="bg-gray-800 text-white p-4 z-50">
     <div class="container mx-auto flex justify-between items-center">
-        <h1 class="text-2xl font-bold"><%= link_to "F T T","/" %> </h1><span class="font-bold text-sm ">football team training</span>
-       
+        <h1 class="text-2xl font-bold"><%= link_to "F T T","/" %> </h1>
     </div>
-
 </header>

--- a/app/views/shared/_before_login_privacy.html.erb
+++ b/app/views/shared/_before_login_privacy.html.erb
@@ -1,6 +1,9 @@
 <div class="bg-gray-100 text-center py-2 text-gray-500 z-40">
-    <div class="bg-blue-500 text-white ">
-       <%= link_to "<<プライバシーポリシー>>", privacy_path, class: "text-sm text-white hover:underline" %>
+  <div class="bg-blue-500 text-white py-2">
+    <div class="flex justify-center space-x-6">
+      <%= link_to "<<プライバシーポリシー>>", privacy_path, class: "text-sm text-white hover:underline" %>
+      <%= link_to "<<利用規約>>", "#", class: "text-sm text-white hover:underline" %>
+      <%= link_to "<<使い方>>", "#", class: "text-sm text-white hover:underline" %>
     </div>
+  </div>
 </div>
-

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="<%= current_user&.admin? ? 'bg-green-100' : 'bg-gray-100' %> text-center py-2 text-xs text-gray-500 z-40">
+<footer class="text-center text-sm text-gray-500 z-40">
   <div class="flex <%= current_user&.admin? ? 'bg-green-600' : 'bg-blue-600' %> text-white">
     <%= link_to "トレーニング登録", new_training_path, class: "flex-1 text-center py-2 hover:bg-gray-700" %>
     <%= link_to "マイトレーニング", trainings_path, class: "flex-1 text-center py-2 hover:bg-gray-700" %>

--- a/app/views/shared/_fotter_fixed.html.erb
+++ b/app/views/shared/_fotter_fixed.html.erb
@@ -2,8 +2,8 @@
   <div class="<%= current_user&.admin? ? 'bg-green-600' : 'bg-blue-600' %> text-white py-2">
     <div class="flex justify-center space-x-6">
       <%= link_to "<<プライバシーポリシー>>", privacy_path, class: "text-sm text-white hover:underline" %>
-      <%= link_to "<<利用規約>>", "#", class: "text-sm text-white hover:underline" %>
-      <%= link_to "<<使い方>>", "#", class: "text-sm text-white hover:underline" %>
+      <%= link_to "<<利用規約>>", terms_of_service_path, class: "text-sm text-white hover:underline" %>
+      <%= link_to "<<使い方>>", how_to_use_path, class: "text-sm text-white hover:underline" %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_fotter_fixed.html.erb
+++ b/app/views/shared/_fotter_fixed.html.erb
@@ -1,8 +1,8 @@
 <div class="text-center py-2 bg-gray-200 text-gray-500 z-40">
   <div class="<%= current_user&.admin? ? 'bg-green-600' : 'bg-blue-600' %> text-white py-2">
     <div class="flex justify-center space-x-6">
-      <%= link_to "<<プライバシーポリシー>>", privacy_path, class: "text-sm text-white hover:underline" %>
       <%= link_to "<<利用規約>>", terms_of_service_path, class: "text-sm text-white hover:underline" %>
+      <%= link_to "<<プライバシーポリシー>>", privacy_path, class: "text-sm text-white hover:underline" %>
       <%= link_to "<<使い方>>", how_to_use_path, class: "text-sm text-white hover:underline" %>
     </div>
   </div>

--- a/app/views/shared/_fotter_fixed.html.erb
+++ b/app/views/shared/_fotter_fixed.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-gray-100 text-center py-2 text-gray-500 z-40">
-  <div class="bg-blue-500 text-white py-2">
+<div class="text-center py-2 bg-gray-200 text-gray-500 z-40">
+  <div class="<%= current_user&.admin? ? 'bg-green-600' : 'bg-blue-600' %> text-white py-2">
     <div class="flex justify-center space-x-6">
       <%= link_to "<<プライバシーポリシー>>", privacy_path, class: "text-sm text-white hover:underline" %>
       <%= link_to "<<利用規約>>", "#", class: "text-sm text-white hover:underline" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,9 +14,13 @@
                    <li class="p-3"><%= link_to "チーム編集", team_path(current_user.team_id) %></li>
                   <% end %>
                 <% end %>
-
-
                 <li class="p-3"><%= link_to "ログアウト", destroy_user_session_path,data: { turbo_method: :delete }%></li>
+                <% if current_user.role == "member" && current_user.team_id.nil? %>
+                <%= button_to "自分でチームを作成する", self_promote_admin_user_path(current_user),
+                   method: :patch,
+                   data: { turbo_confirm: "管理者になってチームを作成しますか？" },
+                   class: "p-3"  %>
+             <% end %>
                 <li class="p-3"><%= link_to "招待", new_team_invitation_path %></li>
             </ul>
         </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,8 +3,8 @@
         <h1 class="text-2xl font-bold"> F T T <%= "(管理者)" if current_user&.admin? %></h1>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
         <nav>
-            <button id="button" type="button" class="fixed z-10 top-6 right-6">
-                <i id="bars" class="fa-solid fa-bars fa-2x"></i>
+            <button id="button" type="button" class="fixed z-10 top-5 right-6">
+                <i id="bars" class="fa-solid fa-bars fa-2x text-gray-400"></i>
             </button>
             <ul id="menu" class="fixed top-0 left-0 w-full text-center <%= current_user&.admin? ? 'bg-green-800' : 'bg-gray-800' %> z-0 transition transform translate-x-full hidden">
                 <li class="p-3"><%= link_to "プロフィール", user_path(current_user) %></li>

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -1,0 +1,3 @@
+<div class="pt-6 text-center">
+<%= link_to "トップページに戻る", root_path, class: "text-blue-600 hover:underline" %>
+</div>

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -1,3 +1,4 @@
 <div class="pt-6 text-center">
+<p>作成中</p>
 <%= link_to "トップページに戻る", root_path, class: "text-blue-600 hover:underline" %>
 </div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-3xl mx-auto p-6 bg-white rounded shadow">
+<div class="max-w-3xl mx-auto p-6 bg-gray-100 rounded shadow mt-10">
   <h1 class="text-2xl font-bold mb-4">プライバシーポリシーおよび個人情報の取り扱いについて</h1>
 
   <p class="mb-4">

--- a/app/views/static_pages/terms_of_service.erb
+++ b/app/views/static_pages/terms_of_service.erb
@@ -1,0 +1,63 @@
+<div class="max-w-3xl mx-auto p-6 bg-gray-100 rounded shadow text-gray-800 mt-10">
+  <h1 class="text-2xl font-bold mb-4">利用規約</h1>
+
+  <p class="mb-4">
+    本利用規約（以下「本規約」といいます）は、F T T（Football Team Training）（以下「当サービス」といいます）の利用条件を定めるものです。ユーザーは、本規約に同意の上、当サービスを利用するものとします。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">1. 適用</h2>
+  <p class="mb-4">
+    本規約は、ユーザーと当サービス運営者との間における当サービスの利用に関するすべての関係に適用されます。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">2. 利用登録</h2>
+  <p class="mb-4">
+    当サービスの利用にあたっては、所定の方法により登録を行い、承認される必要があります。登録情報に虚偽がある場合、利用を制限することがあります。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">3. アカウント管理</h2>
+  <p class="mb-4">
+    ユーザーは、自己の責任においてアカウント情報を管理し、第三者に譲渡・貸与してはなりません。不正使用によって生じた損害について当サービスは一切の責任を負いません。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">4. 禁止事項</h2>
+  <ul class="list-disc ml-6 mb-4">
+    <li>虚偽の情報登録</li>
+    <li>他ユーザーや第三者への誹謗中傷・妨害行為</li>
+    <li>不正アクセス・データ改ざん</li>
+    <li>法令または公序良俗に反する行為</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mb-2">5. サービス内容の変更・中断</h2>
+  <p class="mb-4">
+    当サービスは、ユーザーへの事前通知なく、サービスの全部または一部の内容を変更・中断・終了できるものとします。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">6. 免責事項</h2>
+  <p class="mb-4">
+    当サービスは、ユーザーのトレーニング結果や身体的状態に対する効果・安全性を保証するものではありません。利用により生じた損害について一切責任を負いません。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">7. 退会およびアカウント削除</h2>
+  <p class="mb-4">
+    ユーザーは、所定の手続きによりアカウントを削除し、サービスを退会することができます。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">8. 規約の変更</h2>
+  <p class="mb-4">
+    本規約は、当サービスの判断により変更されることがあります。変更後の規約は当サービス上に掲載された時点で効力を生じます。
+  </p>
+
+  <h2 class="text-xl font-semibold mb-2">9. 準拠法・裁判管轄</h2>
+  <p class="mb-4">
+    本規約は日本法に準拠し、当サービスに関して紛争が生じた場合には、東京地方裁判所を第一審の専属的合意管轄裁判所とします。
+  </p>
+
+  <p class="text-sm text-gray-500 mt-8">
+    最終更新日: 2025年6月
+  </p>
+</div>
+
+<div class="pt-6 text-center">
+  <%= link_to "トップページに戻る", root_path, class: "text-blue-600 hover:underline" %>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -6,10 +6,10 @@
   <% if user_signed_in? %>
    <div class="text-7xl font-bold text-gray-400"> WELCOME </div>
    <% else %>
-   <div class="grid grid-cols-2 gap-3 mb-6">
-    <%= link_to "サインアップ", new_member_registration_path, class: button_class %>
-    <%= link_to "ログイン", user_session_path, class: button_class %>
-   </div>
+   <div class="flex flex-col gap-3 mb-6">
+     <%= link_to "ログイン", user_session_path, class: login_button_class %>
+     <%= link_to "サインアップ", new_member_registration_path, class: button_class %>
+  </div>
   <% end %>
 
   <h2 class="mt-4">チームでトレーニング状況の記録、</h2>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,5 +1,12 @@
-<div class="max-w-xl mx-auto bg-gray-100 shadow-md rounded-lg p-6 mt-8 space-y-4 text-gray-800">
-  <h2 class="text-2xl font-bold text-gray-800 mb-4">チーム詳細</h2>
+<div class="max-w-xl mx-auto bg-gray-100 shadow-md rounded-lg p-6 mt-8 space-y-4 text-gray-800 relative">
+  <div class="flex justify-between items-center mb-4">
+    <h2 class="text-2xl font-bold text-gray-800">チーム詳細</h2>
+    <%= link_to edit_team_path(@team), class: "inline-flex items-center gap-1 text-blue-600 hover:underline font-semibold text-sm" do %>
+      <i class="fa-solid fa-pen"></i>
+      編集
+    <% end %>
+  </div>
+
   <div>
     <span class="font-semibold text-gray-700">チーム名：</span>
     <span><%= @team.name %></span>
@@ -15,15 +22,11 @@
     <span><%= l(@team.created_at, format: :long) %></span>
   </div>
 
-  <div class="mt-6">
-    <%= link_to "編集", edit_team_path(@team), class: "bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded" %>
-    <%= link_to "戻る", trainings_path, class: "ml-2 text-blue-600 hover:underline" %>
-  </div>
 </div>
 
-<div class="text-center pt-5">
 <% if current_user.admin? && current_user.team_id.present? %>
-  <%= link_to "チームを削除する", confirm_destroy_team_path(current_user.team_id),
-      class: "bg-red-600 text-white px-6 py-2 rounded hover:bg-red-700" %>
+  <div class="text-center pt-5">
+    <%= link_to "チームを削除する", confirm_destroy_team_path(current_user.team_id),
+        class: "bg-red-600 text-white px-6 py-2 rounded hover:bg-red-700" %>
+  </div>
 <% end %>
-</div>

--- a/app/views/trainings/_form.html.erb
+++ b/app/views/trainings/_form.html.erb
@@ -15,8 +15,10 @@
 
   <%= form.hidden_field :user_id, value: current_user.id %>
 
+  <h3 class="text-xl font-bold text-gray-800 mb-4">トレーニング詳細</h3>
+
   <div>
-    <%= form.label :＊日付, class: "block font-semibold mb-1" %>
+    <%= form.label :＊日付, class: "block font-semibold mb-1 " %>
     <%= form.datetime_field :datetime, class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
   </div>
 
@@ -38,14 +40,17 @@
     <%= form.text_area :memo, placeholder: "体調  感想  明日の抱負", rows: 2, class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
   </div>
 
+  <hr class="my-6 border-t border-gray-300">
+  <h3 class="text-xl font-bold text-gray-800 mb-4">身体情報</h3>
+
   <div>
     <%= form.label :体重, class: "block font-semibold mb-1" %>
-    <%= form.number_field :body_weight, step: '0.01', placeholder: "半角数字", class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    <%= form.number_field :body_weight, step: '0.01', placeholder: "半角数字(kg)", class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
   </div>
 
   <div>
     <%= form.label :体脂肪率, class: "block font-semibold mb-1" %>
-    <%= form.number_field :body_fat, step: '0.01', placeholder: "半角数字", class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    <%= form.number_field :body_fat, step: '0.01', placeholder: "半角数字(%)", class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
   </div>
 
   <hr class="my-6 border-t border-gray-300">
@@ -54,16 +59,14 @@
 
   <div class="grid gap-4">
   <%= form.fields_for :training_max_weights do |tmw_fields| %>
-    <div class="border p-4 rounded shadow-sm">
       <%= tmw_fields.hidden_field :id %>
       <%= tmw_fields.hidden_field :max_weight_id %>
 
       <% max_weight_name = @max_weights[tmw_fields.object.max_weight_id]&.name || "種目" %>
       <p class="font-semibold text-gray-700 mb-2"><%= max_weight_name %></p>
 
-      <%= tmw_fields.label :record, "重量 (kg)", class: "block mb-1 font-medium" %>
-      <%= tmw_fields.number_field :record, step: '0.01',  placeholder: "半角数字", class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
-    </div>
+    
+      <%= tmw_fields.number_field :record, step: '0.01',  placeholder: "半角数字(kg)", class: "w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
   <% end %>
 </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,11 @@
-<div class="max-w-xl mx-auto bg-gray-100 shadow-md rounded-lg p-6 mt-8 space-y-4 text-gray-800">
-  <h2 class="text-2xl font-bold text-gray-800 mb-4">プロフィール</h2>
+<div class="max-w-xl mx-auto bg-gray-100 shadow-md rounded-lg p-6 mt-8 space-y-4 text-gray-800 relative">
+  <div class="flex justify-between items-center mb-4">
+    <h2 class="text-2xl font-bold text-gray-800">プロフィール</h2>
+    <%= link_to edit_profile_path(current_user), class: "inline-flex items-center gap-1 text-blue-600 hover:underline font-semibold text-sm" do %>
+      <i class="fa-solid fa-pen"></i>
+      編集
+    <% end %>
+  </div>
 
   <div class="mb-4">
     <p class="text-sm text-gray-500 mb-1">所属チーム</p>
@@ -51,24 +57,21 @@
     <p class="text-lg"><%= @user.updated_at.strftime("%Y年%m月%d日 %H:%M") %></p>
   </div>
 
-  <div class="pt-4">
-    <%= link_to "プロフィール編集", edit_profile_path(current_user), class: "inline-block text-blue-600 hover:underline font-semibold" %>
-  </div>
-
-  <% if current_user.team_id.present? %>
-  <div class="pt-4">
-  <%= button_to "チームを脱退する", leave_team_users_path,
-        {
-          method: :patch,
-          data: { turbo_confirm: "本当に脱退しますか？" },
-          class: "inline-block text-blue-600 hover:underline font-semibold bg-transparent border-none p-0"
-        } %>
-  </div>
-  <% end %>
 
 
-
-  <div class="pt-4">
-    <%= link_to "重要事項の変更・削除（パスワード/メールアドレス/アカウント）", edit_user_registration_path(current_user), class: "inline-block text-red-500 hover:underline font-semibold" %>
-  </div>
 </div>
+
+<% if current_user.team_id.present? %>
+  <div class="flex justify-center gap-6 mt-6">
+    <%= button_to "チームを脱退する", leave_team_users_path,
+      method: :patch,
+      data: { turbo_confirm: "本当に脱退しますか？" },
+      class: "text-blue-600 hover:underline font-semibold bg-transparent border-none p-0 text-sm"
+    %>
+
+    <%= link_to "重要事項の変更・削除（パスワード/メールアドレス/アカウント）",
+      edit_user_registration_path(current_user),
+      class: "text-red-500 hover:underline font-semibold text-sm"
+    %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,12 +20,7 @@
       <p class="text-lg font-medium text-gray-500">チームに所属していません</p>
    <% end %>
 
-    <% if current_user.role == "member" && current_user.team_id.nil? %>
-       <%= button_to "自分でチームを作成する", self_promote_admin_user_path,
-          method: :patch,
-          data: { turbo_confirm: "管理者になってチームを作成しますか？" },
-          class: " cursor-pointer rounded-[8px] bg-neutral-200 px-3 py-1 text-sm text-neutral-950 transition-colors hover:bg-neutral-100 active:bg-neutral-50" %>
-    <% end %>
+   
   </div>
 
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
 
   root "static_pages#top"
   get "/privacy", to: "static_pages#privacy"
+  get "/terms_of_service", to: "static_pages#terms_of_service"
+  get "/how_to_use", to: "static_pages#how_to_use"
 
   resources :charts, only: [ :index ]
 


### PR DESCRIPTION
トップページ
・サブタイトル削除
・ログインボタンの強調　縦並びに変更
・ログインしていませんを削除

ヘッダーフッター
・ハンバーガーメニューの色変更
・フッターに利用規約のリンク追加
（フッター上部固定の話もありましたが、携帯での入力をメインに考えており、その際、下部にある方が押しやすいため下に設置してあります。）
・チーム作成ボタンをプロフィール画面からヘッダーに変更
・使い方ページの動線まで作成（中身は空白）

プロフィールなど編集ページ
・プロフィール、チーム情報の編集ボタンに鉛筆マークの追加と右上に配置
。重要事項の変更をカード外に配置

入力フォーム
・枠を削除
・大項目を追加
